### PR TITLE
Clarify pyrag-web startup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ uv run pyrag --add /path/to/your/documents --query "What is this about?"
 uv run pyrag --add https://arxiv.org/pdf/2408.09869 --query "Which are the main AI models in Docling?"
 
 # 4. Use the web interface (optional)
+# From the project root, start the FastAPI app:
 make run-web  # or: uv run pyrag-web
-# Open http://localhost:8000 in your browser
+# Then open http://localhost:8000 in your browser
 ```
 
 ## Installation


### PR DESCRIPTION
## Summary
- clarify in the README that pyrag-web should be started from the project root and accessed via localhost:8000

## Testing
- make qa-quick *(fails: huggingface model download blocked by proxy during tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d89ef674883328b054a963c77d6d7)